### PR TITLE
Allow multiple recipients + optional cc and bcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Double click the node and fill all fields
 ## Payload
 It expects a payload with these properties;
 
-- payload.recipient: Email address to sendo to, should be valid and accept just one address at time.
+- payload.recipient: Email address(es) to sendo to, should be valid. Accept either one address as a string or multiple addresses as an array of strings.
+- payload.cc_recipient: Optional email address(es) to sendo to as carbon-copy (Cc), should be valid. Accept either one address as a string or multiple addresses as an array of strings.
+- payload.bcc_recipient: Optional email address(es) to sendo to as blind-carbon-copy (Bcc), should be valid. Accept either one address as a string or multiple addresses as an array of strings.
 - payload.subject: The email subject, should be short string.
 - payload.body_text: If you want to send a pure text email you should use this property.
 - payload.body_html: The html string to send.
@@ -26,4 +28,3 @@ It returns an Object with the Id of the email sended
     "MessageId":"0101017599fe549f-64676c3d-8dda-478b-9765-228d49de341c-000000"
 }
 ```
-    

--- a/aws-ses.html
+++ b/aws-ses.html
@@ -51,7 +51,11 @@
     <p>It expects a payload with these properties;</p>
     <dl>
         <dt>payload.recipient</dt>
-        <dd>Email address to sendo to, should be valid and accept just one address at time.</dd>
+        <dd>Email address(es) to sendo to, should be valid. Accept either one address as a string or multiple addresses as an array of strings.</dd>
+        <dt>payload.cc_recipient</dt>
+        <dd>Optional email address(es) to sendo to as carbon-copy (Cc), should be valid. Accept either one address as a string or multiple addresses as an array of strings.</dd>
+        <dt>payload.bcc_recipient</dt>
+        <dd>Optional email address(es) to sendo to as blind-carbon-copy (Bcc), should be valid. Accept either one address as a string or multiple addresses as an array of strings.</dd>
         <dt>payload.subject</dt>
         <dd>The email subject, should be short string.</dd>
         <dt>payload.body_text</dt>

--- a/aws-ses.js
+++ b/aws-ses.js
@@ -103,15 +103,15 @@ module.exports = function(RED) {
             if (msg.payload.cc_recipient) {
                 let toCcAddresses = msg.payload.cc_recipient;
                 if (!Array.isArray(toCcAddresses))
-                toCcAddresses = [msg.payload.recipient];
-                params.Message.Destination.CcAddresses = toCcAddresses;
+                    toCcAddresses = [msg.payload.recipient];
+                params.Destination.CcAddresses = toCcAddresses;
             }
 
             if (msg.payload.bcc_recipient) {
                 let toBccAddresses = msg.payload.bcc_recipient;
                 if (!Array.isArray(toBccAddresses))
-                toBccAddresses = [msg.payload.bcc_recipient];
-                params.Message.Destination.BccAddresses = toBccAddresses;
+                    toBccAddresses = [msg.payload.bcc_recipient];
+                params.Destination.BccAddresses = toBccAddresses;
             }
 
             if (msg.payload.body_text) {

--- a/aws-ses.js
+++ b/aws-ses.js
@@ -103,7 +103,7 @@ module.exports = function(RED) {
             if (msg.payload.cc_recipient) {
                 let toCcAddresses = msg.payload.cc_recipient;
                 if (!Array.isArray(toCcAddresses))
-                    toCcAddresses = [msg.payload.recipient];
+                    toCcAddresses = [msg.payload.cc_recipient];
                 params.Destination.CcAddresses = toCcAddresses;
             }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-aws-ses-send",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-aws-ses-send",
-  "version": "0.0.1",
+  "version": "0.9.1",
   "description": "Enable the send of e-mails with AWS contrib",
   "main": "aws-ses.js",
   "scripts": {


### PR DESCRIPTION
Thanks for your great node.
Please accept this little improvement.

This is a non-breaking change allowing to specify either a single recipient or multiple recipient.
It also adds optional `cc_recipient` and `bcc_recipient` optionnal fields to specify a carbon-copy and blind-carbon-copy.

For all 3, it can be specified a single recipient as already:
```
msg.payload.recipient = "foo@bar.net"
```
Or as multiple recipients:
```
msg.payload.recipient = [ "foo@bar.net", "bar@foo.com" ]
```
